### PR TITLE
Added two new components, PivotNoBootstrap and PivotTableNoBootstrap

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -25,7 +25,7 @@
     </div>
 
     <h2 class="border-bottom pb-2 mb-4">PivotTable <small>(standalone)</small></h2>
-    
+
     <div class="mb-5">
       <pivot-table
         :data="asyncData"
@@ -51,17 +51,41 @@
         </template>
       </pivot-table>
     </div>
+
+    <h2 class="border-bottom pb-2 mb-4">Pivot <small>(drag & drop UI + PivotTable <strong>without bootstrap</strong>)</small></h2>
+
+    <div class="mb-5">
+      <pivot-no-bootstrap
+        :data="data"
+        :fields="fields"
+        :row-fields="rowFields"
+        :col-fields="colFields"
+        :reducer="reducer"
+        :default-show-settings="defaultShowSettings"
+      >
+        <template slot="value" slot-scope="{ value }">
+          {{ value | number }}
+        </template>
+        <template slot="genderHeader" slot-scope="{ value }">
+          <svg v-if="value == 'female'" aria-hidden="true" data-prefix="fas" data-icon="venus" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 288 512" class="svg-inline--fa fa-venus fa-fw"><path fill="currentColor" d="M288 176c0-79.5-64.5-144-144-144S0 96.5 0 176c0 68.5 47.9 125.9 112 140.4V368H76c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h36v36c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12v-36h36c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-36v-51.6c64.1-14.5 112-71.9 112-140.4zm-224 0c0-44.1 35.9-80 80-80s80 35.9 80 80-35.9 80-80 80-80-35.9-80-80z" class=""></path></svg>
+          <svg v-else-if="value == 'male'" aria-hidden="true" data-prefix="fas" data-icon="mars" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="svg-inline--fa fa-mars fa-fw"><path fill="currentColor" d="M372 64h-79c-10.7 0-16 12.9-8.5 20.5l16.9 16.9-80.7 80.7c-22.2-14-48.5-22.1-76.7-22.1C64.5 160 0 224.5 0 304s64.5 144 144 144 144-64.5 144-144c0-28.2-8.1-54.5-22.1-76.7l80.7-80.7 16.9 16.9c7.6 7.6 20.5 2.2 20.5-8.5V76c0-6.6-5.4-12-12-12zM144 384c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z" class=""></path></svg>
+          {{ value | capitalize }}
+        </template>
+      </pivot-no-bootstrap>
+    </div>
   </div>
 </template>
 
 <script>
 import Pivot from '../src/Pivot'
 import PivotTable from '../src/PivotTable'
+import PivotNoBootstrap from '../src/PivotNoBootstrap/PivotNoBootstrap'
+import PivotTableNoBootstrap from '../src/PivotNoBootstrap/PivotTableNoBootstrap'
 import data from './data'
 
 export default {
   name: 'app',
-  components: { Pivot, PivotTable },
+  components: { Pivot, PivotTable, PivotNoBootstrap, PivotTableNoBootstrap },
   data: () => {
     return {
       data: data,

--- a/src/PivotNoBootstrap/PivotNoBootstrap.vue
+++ b/src/PivotNoBootstrap/PivotNoBootstrap.vue
@@ -1,0 +1,451 @@
+<template>
+  <div class="pivot-no-bootstrap">
+    <!-- Top row -->
+    <div v-if="showSettings" class="layout nowrap-row mb-4">
+      <div class="layout flex align-start hide-settings">
+        <button class="btn-no-bootstrap btn-no-bootstrap-primary" @click="toggleShowSettings">
+          {{ hideSettingsText }}
+        </button>
+      </div>
+
+      <!-- Disabled fields -->
+      <div class="layout flex available-fields">
+        <div class="drag-area-label">{{ availableFieldsLabelText }}</div>
+        <draggable v-model="internal.fields" class="layout wrap-row drag-area" :class="dragAreaClass" :options="{ group: 'fields' }" @start="start" @end="end">
+          <div v-for="field in internal.fields" :key="field.key">
+            <div class="btn-no-bootstrap btn-draggable btn-no-bootstrap-secondary">
+              <svg aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 270 512" class="svg-inline--fa fa-grip-vertical fa-w-10"><path fill="currentColor" d="M64 208c26.5 0 48 21.5 48 48s-21.5 48-48 48-48-21.5-48-48 21.5-48 48-48zM16 104c0 26.5 21.5 48 48 48s48-21.5 48-48-21.5-48-48-48-48 21.5-48 48zm0 304c0 26.5 21.5 48 48 48s48-21.5 48-48-21.5-48-48-48-48 21.5-48 48z M204 208c26.5 0 48 21.5 48 48s-21.5 48 -48 48 -48 -21.5 -48 -48 21.5 -48 48 -48zM156 104c0 26.5 21.5 48 48 48s48 -21.5 48 -48 -21.5 -48 -48 -48 -48 21.5 -48 48zm0 304c0 26.5 21.5 48 48 48s48 -21.5 48 -48 -21.5 -48 -48 -48 -48 21.5 -48 48z" class=""></path></svg>
+              {{ field.label }}
+            </div>
+          </div>
+        </draggable>
+      </div>
+    </div>
+
+    <div class="mb-4" v-else>
+      <button class="btn-no-bootstrap btn-no-bootstrap-primary" @click="toggleShowSettings">
+        {{ showSettingsText }}
+      </button>
+    </div>
+
+    <div class="layout nowrap-row mb-4" v-if="showSettings">
+      <!-- Top left zone - TODO: renderer select menu -->
+      <div class="layout flex"></div>
+
+      <!-- Horizontal fields -->
+      <div class="layout flex columns">
+        <div class="drag-area-label">{{ colsLabelText }}</div>
+        <draggable v-model="internal.colFields" :options="{ group: 'fields' }" @start="start" @end="end" class="layout wrap-row drag-area border-primary" :class="dragAreaClass">
+          <div v-for="field in internal.colFields" :key="field.key">
+            <div class="btn-no-bootstrap btn-draggable btn-no-bootstrap-secondary">
+              <svg aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 270 512" class="svg-inline--fa fa-grip-vertical fa-w-10"><path fill="currentColor" d="M64 208c26.5 0 48 21.5 48 48s-21.5 48-48 48-48-21.5-48-48 21.5-48 48-48zM16 104c0 26.5 21.5 48 48 48s48-21.5 48-48-21.5-48-48-48-48 21.5-48 48zm0 304c0 26.5 21.5 48 48 48s48-21.5 48-48-21.5-48-48-48-48 21.5-48 48z M204 208c26.5 0 48 21.5 48 48s-21.5 48 -48 48 -48 -21.5 -48 -48 21.5 -48 48 -48zM156 104c0 26.5 21.5 48 48 48s48 -21.5 48 -48 -21.5 -48 -48 -48 -48 21.5 -48 48zm0 304c0 26.5 21.5 48 48 48s48 -21.5 48 -48 -21.5 -48 -48 -48 -48 21.5 -48 48z" class=""></path></svg>
+              {{ field.label }}
+            </div>
+          </div>
+        </draggable>
+      </div>
+    </div>
+
+    <div class="layout nowrap-row">
+      <!-- Vertical fields -->
+      <div class="rows" v-if="showSettings">
+        <div class="drag-area-label">{{ rowsLabelText }}</div>
+        <draggable v-model="internal.rowFields" :options="{ group: 'fields' }" @start="start" @end="end" class="layout wrap-column align-start drag-area border-primary" :class="dragAreaClass">
+          <div v-for="field in internal.rowFields" :key="field.key">
+            <div class="btn-no-bootstrap btn-draggable btn-no-bootstrap-secondary">
+              <svg aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 270 512" class="svg-inline--fa fa-grip-vertical fa-w-10"><path fill="currentColor" d="M64 208c26.5 0 48 21.5 48 48s-21.5 48-48 48-48-21.5-48-48 21.5-48 48-48zM16 104c0 26.5 21.5 48 48 48s48-21.5 48-48-21.5-48-48-48-48 21.5-48 48zm0 304c0 26.5 21.5 48 48 48s48-21.5 48-48-21.5-48-48-48-48 21.5-48 48z M204 208c26.5 0 48 21.5 48 48s-21.5 48 -48 48 -48 -21.5 -48 -48 21.5 -48 48 -48zM156 104c0 26.5 21.5 48 48 48s48 -21.5 48 -48 -21.5 -48 -48 -48 -48 21.5 -48 48zm0 304c0 26.5 21.5 48 48 48s48 -21.5 48 -48 -21.5 -48 -48 -48 -48 21.5 -48 48z" class=""></path></svg>
+              {{ field.label }}
+            </div>
+          </div>
+        </draggable>
+      </div>
+
+      <!-- Table -->
+      <div class="table">
+        <pivot-table-no-bootstrap :data="data" :row-fields="internal.rowFields" :col-fields="internal.colFields" :reducer="reducer" :no-data-warning-text="noDataWarningText" :is-data-loading="isDataLoading">
+          <!-- pass down scoped slots -->
+          <template v-for="(slot, slotName) in $scopedSlots" :slot="slotName" slot-scope="{ value }">
+            <slot :name="slotName" v-bind="{ value }"></slot>
+          </template>
+          <template slot="loading">
+            <slot name="loading"></slot>
+          </template>
+        </pivot-table-no-bootstrap>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import PivotTableNoBootstrap from './PivotTableNoBootstrap'
+import Draggable from 'vuedraggable'
+
+export default {
+  name: 'vue-pivot',
+  components: { PivotTableNoBootstrap, Draggable },
+  props: {
+    data: {
+      type: Array,
+      default: []
+    },
+    fields: {
+      type: Array,
+      default: []
+    },
+    rowFields: {
+      type: Array,
+      default: []
+    },
+    colFields: {
+      type: Array,
+      default: []
+    },
+    reducer: {
+      type: Function,
+      default: (sum, item) => sum + 1
+    },
+    defaultShowSettings: {
+      type: Boolean,
+      default: true
+    },
+    availableFieldsLabelText: {
+      type: String,
+      default: 'Available fields'
+    },
+    colsLabelText: {
+      type: String,
+      default: 'Columns'
+    },
+    rowsLabelText: {
+      type: String,
+      default: 'Rows'
+    },
+    hideSettingsText: {
+      type: String,
+      default: 'Hide settings'
+    },
+    showSettingsText: {
+      type: String,
+      default: 'Show settings'
+    },
+    noDataWarningText: {
+      type: String,
+      default: 'No data to display.'
+    },
+    isDataLoading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data: function() {
+    return {
+      internal: {
+        fields: this.fields,
+        rowFields: this.rowFields,
+        colFields: this.colFields
+      },
+      dragging: false,
+      showSettings: true
+    }
+  },
+  computed: {
+    dragAreaClass: function() {
+      return this.dragging ? 'drag-area-highlight' : null
+    }
+  },
+  methods: {
+    toggleShowSettings: function() {
+      this.showSettings = !this.showSettings
+    },
+    start: function() {
+      this.dragging = true
+    },
+    end: function() {
+      this.dragging = false
+    }
+  },
+  created: function() {
+    this.showSettings = this.defaultShowSettings
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import url('https://fonts.googleapis.com/css?family=Segoe UI');
+@import url('https://fonts.googleapis.com/css?family=Roboto');
+@import url('https://fonts.googleapis.com/css?family=Helvetica');
+//main
+.pivot-no-bootstrap {
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+//spacing
+.mb-4 {
+  margin-bottom: 16px * 1.5;
+}
+
+//flex
+.layout {
+  display: flex;
+  flex-direction: row;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.flex {
+  flex: 1 1 auto;
+  @media screen and (min-width: 0) {
+    flex-basis: 100%;
+    flex-grow: 0;
+    max-width: 100%;
+  }
+  @media screen and (min-width: 600px) {
+    flex-basis: 50%;
+    flex-grow: 0;
+    max-width: 50%;
+  }
+  @media screen and (min-width: 960px) {
+    flex-basis: 33.33333333333333%;
+    flex-grow: 0;
+    max-width: 33.33333333333333%;
+  }
+  @media screen and (min-width: 1264px) {
+    flex-basis: 25%;
+    flex-grow: 0;
+    max-width: 25%;
+  }
+}
+
+.column {
+  flex-direction: column;
+}
+
+.wrap {
+  flex-direction: wrap;
+}
+
+.no-wrap {
+  flex-direction: nowrap;
+}
+
+.wrap-row {
+  flex-flow: row wrap;
+}
+
+.nowrap-row {
+  flex-flow: row nowrap;
+}
+
+.nowrap-column {
+  flex-flow: column nowrap;
+}
+
+.wrap-column {
+  flex-flow: column wrap;
+}
+
+.align-center {
+  align-items: center;
+}
+
+.align-baseline {
+  align-items: baseline;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-end {
+  justify-content: flex-end;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.content-center {
+  align-content: center;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.align-start {
+  align-items: flex-start;
+}
+
+.align-end {
+  align-items: flex-end;
+}
+
+.spacer {
+  flex-grow: 1;
+}
+
+.self-end {
+  align-self: flex-end;
+}
+
+.no-border {
+  border: 0 !important;
+}
+
+.pointer {
+  cursor: pointer;
+}
+
+.space-between {
+  justify-content: space-between;
+}
+
+.space-around {
+  justify-content: space-around;
+}
+
+//others
+.available-fields, .columns {
+  flex-basis: 100%;
+  max-width: 100%;
+  width: 100%;
+}
+
+.rows {
+  min-width: 200px;
+  max-width: 200px;
+  margin-right: 1.37rem;
+}
+
+.table {
+  margin-top: -2.5px;
+  min-width: calc(100% - 13.7rem);
+}
+
+.btn-no-bootstrap-primary, .btn-no-bootstrap-secondary {
+  background-image: none;
+  background-color: #fff;
+  border-color: transparent;
+  color: #0052cc;
+  text-decoration: none;
+  font-weight: 600;
+  transition: all .2s ease-out;
+  border: 1px solid #0052cc;
+}
+
+.btn-no-bootstrap-primary:hover, .btn-no-bootstrap-secondary:hover {
+  background-color: #0052cc;
+  color: #fff;
+}
+
+.btn-no-bootstrap-secondary {
+  background-color: #0052cc;
+  color: #fff;
+  will-change: opacity !important;
+  transition: all .2s ease-out !important
+}
+
+.btn-no-bootstrap-secondary:hover {
+  background-color: #0052cc;
+  color: #fff;
+  opacity: .7;
+}
+
+.btn-no-bootstrap {
+  box-sizing: border-box;
+  transition: background-color .1s ease-out;
+  border-radius: 3.01px;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 16px;
+  font-variant: normal;
+  display: inline-block;
+  height: 2.14285714em;
+  line-height: 1.42857143em;
+  margin: 0;
+  padding: 6px 16px;
+  vertical-align: baseline;
+  white-space: nowrap;
+}
+
+.w200 {
+  min-width: 200px;
+  max-width: 200px;
+}
+
+.border-primary {
+  border-color: #007bff !important;
+}
+
+/* Left column width */
+.left-col {
+  min-width: 200px;
+  max-width: 200px;
+}
+
+/* Grid with even gutters */
+.grid-x {
+  margin: 0 -0.75rem;
+  > * {
+    padding: 0 0.75rem;
+  }
+}
+
+/* Drag & drop stuff */
+.drag-area {
+  min-width: 10rem;
+  min-height: 6.5rem;
+  border: 1px dashed #ccc;
+  padding: 0.5rem;
+  transition: background-color 0.4s;
+
+  > div {
+    margin: 0.5rem;
+  }
+
+  * {
+    cursor: move !important;
+  }
+
+  padding-top: 2.5rem;
+}
+
+.drag-area-highlight {
+  background-color: #f3f3f3;
+}
+
+.drag-area-label {
+  position: absolute;
+  padding: 0.75rem 1rem;
+}
+
+.sortable-ghost {
+  opacity: 0.4;
+}
+
+/* Handle icon (mix of grip-vertical & ellipsis-v) */
+.svg-inline--fa.fa-w-10 {
+  width: 0.625em;
+}
+
+.svg-inline--fa {
+  display: inline-block;
+  font-size: inherit;
+  height: 1em;
+  overflow: visible;
+  vertical-align: -.125em;
+}
+
+.btn-draggable .fa-grip-vertical {
+  margin-left: -0.375rem;
+  margin-right: 0.375rem;
+}
+
+/* Draggable buttons */
+.btn-draggable {
+  white-space: normal;
+  text-align: left;
+}
+</style>

--- a/src/PivotNoBootstrap/PivotTableNoBootstrap.vue
+++ b/src/PivotNoBootstrap/PivotTableNoBootstrap.vue
@@ -1,0 +1,342 @@
+<template>
+  <div class="table-responsive-no-bootstrap">
+    <template v-if="isDataLoading">
+      <slot name="loading">
+        Loading...
+      </slot>
+    </template>
+    <div v-else-if="data.length === 0" class="alert alert-warning" role="alert">
+      {{ noDataWarningText }}
+    </div>
+    <table v-else class="table table-bordered-no-bootstrap">
+
+      <!-- Table header -->
+      <thead>
+        <tr v-for="(colField, colFieldIndex) in colFields" :key="colField.key" v-if="colField.showHeader === undefined || colField.showHeader">
+          <!-- Top left dead zone -->
+          <th v-if="colFieldIndex === firstColFieldHeaderIndex && rowHeaderSize > 0" :colspan="rowHeaderSize" :rowspan="colHeaderSize"></th>
+          <!-- Column headers -->
+          <th v-for="(col, colIndex) in cols" :key="JSON.stringify(col)" :colspan="spanSize(cols, colFieldIndex, colIndex)" v-if="spanSize(cols, colFieldIndex, colIndex) !== 0">
+            <slot v-if="colField.headerSlotName" :name="colField.headerSlotName" v-bind:value="col[colFieldIndex]">
+              Missing slot <code>{{ colField.headerSlotName }}</code>
+            </slot>
+            <template v-else>
+              {{ col[colFieldIndex] }}
+            </template>
+          </th>
+          <!-- Top right dead zone -->
+          <th v-if="colFieldIndex === firstColFieldHeaderIndex && rowFooterSize > 0" :colspan="rowFooterSize" :rowspan="colFooterSize"></th>
+        </tr>
+      </thead>
+
+      <!-- Table body -->
+      <tbody>
+        <tr v-for="(row, rowIndex) in rows" :key="JSON.stringify(row)">
+          <!-- Row headers -->
+          <th v-for="(rowField, rowFieldIndex) in rowFields" :key="rowField.key" :rowspan="spanSize(rows, rowFieldIndex, rowIndex)"  v-if="(rowField.showHeader === undefined || rowField.showHeader) && spanSize(rows, rowFieldIndex, rowIndex) !== 0">
+            <slot v-if="rowField.headerSlotName" :name="rowField.headerSlotName" v-bind:value="row[rowFieldIndex]">
+              Missing slot <code>{{ rowField.headerSlotName }}</code>
+            </slot>
+            <template v-else>
+              {{ row[rowFieldIndex] }}
+            </template>
+          </th>
+          <!-- Values -->
+          <td v-for="col in cols" :key="JSON.stringify(col)" class="text-right">
+            <slot v-if="$scopedSlots.value" name="value" v-bind:value="values[JSON.stringify({ col, row })]" />
+            <template v-else>{{ values[JSON.stringify({ col, row })] }}</template>
+          </td>
+          <!-- Row footers (if slots are provided) -->
+          <th v-for="(rowField, rowFieldIndex) in rowFieldsReverse" :key="rowField.key" :rowspan="spanSize(rows, rowFields.length - rowFieldIndex - 1, rowIndex)" v-if="rowField.showFooter && spanSize(rows, rowFields.length - 1 - rowFieldIndex, rowIndex) !== 0">
+            <slot v-if="rowField.footerSlotName" :name="rowField.footerSlotName" v-bind:value="row[rowFields.length - rowFieldIndex - 1]">
+              Missing slot <code>{{ rowField.footerSlotName }}</code>
+            </slot>
+            <template v-else>
+              {{ row[rowFields.length - rowFieldIndex - 1] }}
+            </template>
+          </th>
+        </tr>
+      </tbody>
+
+      <!-- Table footer -->
+      <tfoot>
+        <tr v-for="(colField, colFieldIndex) in colFieldsReverse" :key="colField.key" v-if="colField.showFooter">
+          <!-- Bottom left dead zone -->
+          <th v-if="colFieldIndex === firstColFieldFooterIndex && rowHeaderSize > 0" :colspan="rowHeaderSize" :rowspan="colHeaderSize"></th>
+          <!-- Column footers -->
+          <th v-for="(col, colIndex) in cols" :key="JSON.stringify(col)" :colspan="spanSize(cols, colFields.length - colFieldIndex - 1, colIndex)" v-if="spanSize(cols, colFields.length - colFieldIndex - 1, colIndex) !== 0">
+            <slot v-if="colField.footerSlotName" :name="colField.footerSlotName" v-bind:value="col[colFields.length - colFieldIndex - 1]">
+              Missing slot <code>{{ colField.footerSlotName }}</code>
+            </slot>
+            <template v-else>
+              {{ col[colFields.length - colFieldIndex - 1] }}
+            </template>
+          </th>
+          <!-- Bottom right dead zone -->
+          <th v-if="colFieldIndex === firstColFieldFooterIndex && rowFooterSize > 0" :colspan="rowFooterSize" :rowspan="colFooterSize"></th>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</template>
+
+<script>
+import naturalSort from 'javascript-natural-sort'
+
+export default {
+  props: ['data', 'rowFields', 'colFields', 'reducer', 'noDataWarningText'],
+  props: {
+    data: {
+      type: Array,
+      default: []
+    },
+    rowFields: {
+      type: Array,
+      default: []
+    },
+    colFields: {
+      type: Array,
+      default: []
+    },
+    reducer: {
+      type: Function,
+      default: (sum, item) => sum + 1
+    },
+    noDataWarningText: {
+      type: String,
+      default: 'No data to display.'
+    },
+    isDataLoading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data: function() {
+    return {
+      values: {} // Alas vue does not support js Map
+    }
+  },
+  computed: {
+    cols: function() {
+      const cols = []
+
+      const extractColsRecursive = (depth, filters) => {
+        const getter = this.colFields[depth].getter
+        const sort = this.colFields[depth].sort || naturalSort
+        const values = [...new Set(this.filteredData({ data: this.data, colFilters: filters }).map(item => getter(item)))].sort(sort)
+
+        values.forEach(value => {
+          // Build new filter hash
+          const valueFilters = Object.assign({}, filters)
+          valueFilters[depth] = value
+
+          // Recursive call
+          if (depth + 1 < this.colFields.length) {
+            extractColsRecursive(depth + 1, valueFilters)
+          } else {
+            cols.push(valueFilters)
+          }
+        })
+      }
+
+      if (this.colFields.length > 0) {
+        extractColsRecursive(0, {})
+      } else {
+        cols.push({})
+      }
+
+      return cols
+    },
+    rows: function() {
+      const rows = []
+
+      const extractRowsRecursive = (depth, filters) => {
+        const getter = this.rowFields[depth].getter
+        const sort = this.rowFields[depth].sort || naturalSort
+        const values = [...new Set(this.filteredData({ data: this.data, rowFilters: filters }).map(item => getter(item)))].sort(sort)
+
+        values.forEach(value => {
+          // Build new filter hash
+          const valueFilters = Object.assign({}, filters)
+          valueFilters[depth] = value
+
+          // Recursive call
+          if (depth + 1 < this.rowFields.length) {
+            extractRowsRecursive(depth + 1, valueFilters)
+          } else {
+            rows.push(valueFilters)
+          }
+        })
+      }
+
+      if (this.rowFields.length > 0) {
+        extractRowsRecursive(0, {})
+      } else {
+        rows.push({})
+      }
+
+      return rows
+    },
+    // Compound property for watch single callback
+    colsAndRows: function() {
+      return [this.cols, this.rows]
+    },
+    // Reversed props for footer iterators
+    colFieldsReverse: function() {
+      return this.colFields.slice().reverse()
+    },
+    rowFieldsReverse: function() {
+      return this.rowFields.slice().reverse()
+    },
+    // Number of col header rows
+    colHeaderSize: function() {
+      return this.colFields.filter(colField => colField.showHeader === undefined || colField.showHeader).length
+    },
+    // Number of col footer rows
+    colFooterSize: function() {
+      return this.colFields.filter(colField => colField.showFooter).length
+    },
+    // Number of row header columns
+    rowHeaderSize: function() {
+      return this.rowFields.filter(rowField => rowField.showHeader === undefined || rowField.showHeader).length
+    },
+    // Number of row footer columns
+    rowFooterSize: function() {
+      return this.rowFields.filter(rowField => rowField.showFooter).length
+    },
+    // Index of the first column field header to show - used for table header dead zones
+    firstColFieldHeaderIndex: function() {
+      return this.colFields.findIndex(colField => colField.showHeader === undefined || colField.showHeader)
+    },
+    // Index of the first column field footer to show - used for table footer dead zones
+    firstColFieldFooterIndex: function() {
+      return this.colFieldsReverse.findIndex(colField => colField.showFooter)
+    }
+  },
+  methods: {
+    // Get data filtered
+    filteredData: function({ data = [], colFilters = {}, rowFilters = {} }) {
+      // Prepare getters
+      const colGetters = {}, rowGetters = {}
+
+      for (const depth in colFilters) {
+        colGetters[depth] = this.colFields[depth].getter
+      }
+
+      for (const depth in rowFilters) {
+        rowGetters[depth] = this.rowFields[depth].getter
+      }
+
+      // Filter data with getters
+      return data.filter(item => {
+        let keep = true
+
+        for (const depth in colFilters) {
+          if (colGetters[depth](item) !== colFilters[depth]) {
+            keep = false
+            break
+          }
+        }
+
+        if (keep) {
+          for (const depth in rowFilters) {
+            if (rowGetters[depth](item) !== rowFilters[depth]) {
+              keep = false
+              break
+            }
+          }
+        }
+
+        return keep
+      })
+    },
+    // Get colspan/rowspan size
+    spanSize: function(values, fieldIndex, valueIndex) {
+      // If left value === current value
+      // and top value === 0 (= still in the same top bracket)
+      // The left td will take care of the display
+      if (valueIndex > 0 &&
+        values[valueIndex - 1][fieldIndex] === values[valueIndex][fieldIndex] &&
+        (fieldIndex === 0 || (this.spanSize(values, fieldIndex - 1, valueIndex) === 0))) {
+        return 0
+      }
+
+      // Otherwise, count entries on the right with the same value
+      // But stop if the top value !== 0 (= the top bracket has changed)
+      let size = 1
+      let i = valueIndex
+      while (i + 1 < values.length &&
+        values[i + 1][fieldIndex] === values[i][fieldIndex] &&
+        (fieldIndex === 0 || (i + 1 < values.length && this.spanSize(values, fieldIndex - 1, i + 1) === 0))) {
+        i++
+        size++
+      }
+
+      return size
+    },
+    // Called when cols/rows have changed => recompute values
+    computeValues: function() {
+      // Remove old values
+      this.values = {}
+
+      // Compute new values
+      this.rows.forEach(row => {
+        const rowData = this.filteredData({ data: this.data, rowFilters: row })
+        this.cols.forEach(col => {
+          const data = this.filteredData({ data: rowData, colFilters: col })
+
+          const key = JSON.stringify({ col, row })
+          const value = data.reduce(this.reducer, 0)
+          this.values[key] = value
+        })
+      })
+    }
+  },
+  watch: {
+    colsAndRows: function() {
+      this.computeValues()
+    }
+  },
+  created: function() {
+    this.computeValues()
+  }
+}
+</script>
+
+<style scoped>
+.table-responsive-no-bootstrap th {
+  color: #7a869a;
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.66666667;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 7px 10px;
+  text-align: center;
+  vertical-align: top;
+  min-width: 100%;
+}
+
+.table-responsive-no-bootstrap td {
+  border-top: 1px solid #dfe1e6;
+  padding: 7px 10px;
+  text-align: right;
+  vertical-align: top;
+  min-width: 100%;
+}
+
+.table-responsive-no-bootstrap tr {
+  background: #fff;
+  color: #172b4d;
+}
+
+.table-bordered-no-bootstrap, .table-responsive-no-bootstrap {
+  width: inherit;
+  max-width: inherit;
+  min-width: inherit;
+}
+
+.table-bordered-no-bootstrap td, .table-bordered-no-bootstrap th {
+  border: 1px solid #dee2e6;
+}
+</style>

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,7 +1,11 @@
 import Pivot from './Pivot'
 import PivotTable from './PivotTable'
+import PivotNoBootstrap from './PivotNoBootstrap/PivotNoBootstrap'
+import PivotTableNoBootstrap from './PivotNoBootstrap/PivotTableNoBootstrap'
 
 export function install(Vue, options) {
   Vue.component('pivot', Pivot)
   Vue.component('pivot-table', PivotTable)
+  Vue.component('pivot-no-bootstrap', PivotNoBootstrap)
+  Vue.component('pivot-table-no-bootstrap', PivotTableNoBootstrap)
 }


### PR DESCRIPTION
The main reason is not to depend on bootstrap, so the main changes were the classes and css. Added in the App.vue one example and imports in that file and browser.js.

I did not reuse the code and refactor any of it. This is because if you do not want to accept, I will need this component up and running on my on and fast.

In my project I can't use bootstrap and any of bootstrap css, so this is some workaround it.

If you want, I could refactor in some mixins or some smaller components, and also reuse some of the duplicated css. It's your call to accept this PR or not.

Great work btw. Helped me a lot!

**Note:** I changed the styles a bit to look like [Atlassian AUI Tables](https://docs.atlassian.com/aui/7.9.9/docs/tables.html) and [Atlassian AUI Buttons](https://docs.atlassian.com/aui/7.9.9/docs/buttons.html).